### PR TITLE
Add new API for threadsafe tryCall.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,5 @@ jdk:
 cache:
   directories:
   - "$HOME/.m2/repository"
+
+dist: trusty

--- a/src/main/java/com/coveo/spillway/storage/AsyncBatchLimitUsageStorage.java
+++ b/src/main/java/com/coveo/spillway/storage/AsyncBatchLimitUsageStorage.java
@@ -121,6 +121,11 @@ public class AsyncBatchLimitUsageStorage implements LimitUsageStorage {
     return cache.addAndGet(requests);
   }
 
+  @Override
+  public Map<LimitKey, Integer> addAndGetWithLimit(Collection<AddAndGetRequest> requests) {
+    return cache.addAndGetWithLimit(requests);
+  }
+
   public Map<LimitKey, Integer> debugCacheLimitCounters() {
     return cache.getCurrentLimitCounters();
   }

--- a/src/main/java/com/coveo/spillway/storage/AsyncLimitUsageStorage.java
+++ b/src/main/java/com/coveo/spillway/storage/AsyncLimitUsageStorage.java
@@ -75,6 +75,14 @@ public class AsyncLimitUsageStorage implements LimitUsageStorage {
   }
 
   @Override
+  public Map<LimitKey, Integer> addAndGetWithLimit(Collection<AddAndGetRequest> requests) {
+    Map<LimitKey, Integer> cachedEntries = cache.addAndGetWithLimit(requests);
+    executorService.submit(() -> sendAndCacheRequests(requests));
+
+    return cachedEntries;
+  }
+
+  @Override
   public Map<LimitKey, Integer> getCurrentLimitCounters() {
     return wrappedLimitUsageStorage.getCurrentLimitCounters();
   }

--- a/src/main/java/com/coveo/spillway/storage/InMemoryStorage.java
+++ b/src/main/java/com/coveo/spillway/storage/InMemoryStorage.java
@@ -74,6 +74,20 @@ public class InMemoryStorage implements LimitUsageStorage {
   }
 
   @Override
+  public Map<LimitKey, Integer> addAndGetWithLimit(Collection<AddAndGetRequest> requests) {
+    Map<LimitKey, Integer> updatedEntries = new HashMap<>();
+    requests.forEach(
+        request -> {
+          LimitKey limitKey = LimitKey.fromRequest(request);
+          Capacity counter = map.computeIfAbsent(limitKey, (key) -> new Capacity());
+          updatedEntries.put(
+              limitKey, counter.addAndGetWithLimit(request.getCost(), request.getLimit()));
+        });
+    removeExpiredEntries();
+    return updatedEntries;
+  }
+
+  @Override
   public void close() {}
 
   public void overrideKeys(List<OverrideKeyRequest> overrides) {

--- a/src/main/java/com/coveo/spillway/storage/LimitUsageStorage.java
+++ b/src/main/java/com/coveo/spillway/storage/LimitUsageStorage.java
@@ -116,6 +116,15 @@ public interface LimitUsageStorage {
   Map<LimitKey, Integer> addAndGet(Collection<AddAndGetRequest> requests);
 
   /**
+   * Processes all {@link AddAndGetRequest} and returns the current count for each limit while respecting the request max limit.
+   * When max limit is met, it will return the limit + cost.
+   *
+   * @param requests An collection of {@link AddAndGetRequest} that wrap all necessary information to perform the increments
+   * @return A Map of the limits and their current count
+   */
+  Map<LimitKey, Integer> addAndGetWithLimit(Collection<AddAndGetRequest> requests);
+
+  /**
    * Returns all enforced limits with their current count
    *
    * <p><b>Use with caution, this could be a costly operation</b></p>

--- a/src/main/java/com/coveo/spillway/storage/utils/AddAndGetRequest.java
+++ b/src/main/java/com/coveo/spillway/storage/utils/AddAndGetRequest.java
@@ -47,6 +47,7 @@ public class AddAndGetRequest {
   private Duration expiration;
   private Instant eventTimestamp;
   private int cost;
+  private int limit;
 
   private Instant bucket;
 
@@ -82,6 +83,10 @@ public class AddAndGetRequest {
     return bucket;
   }
 
+  public int getLimit() {
+    return limit;
+  }
+
   private AddAndGetRequest(Builder builder) {
     resource = builder.resource;
     limitName = builder.limitName;
@@ -90,6 +95,7 @@ public class AddAndGetRequest {
     expiration = builder.expiration;
     eventTimestamp = builder.eventTimestamp;
     cost = builder.cost;
+    limit = builder.limit;
     bucket = LimitUtils.calculateBucket(eventTimestamp, expiration);
   }
 
@@ -115,6 +121,7 @@ public class AddAndGetRequest {
     private Duration expiration;
     private Instant eventTimestamp;
     private int cost = 1;
+    private int limit;
 
     public Builder() {}
 
@@ -126,6 +133,7 @@ public class AddAndGetRequest {
       this.expiration = other.expiration;
       this.eventTimestamp = other.eventTimestamp;
       this.cost = other.cost;
+      this.limit = other.limit;
     }
 
     public Builder withResource(String val) {
@@ -163,6 +171,11 @@ public class AddAndGetRequest {
       return this;
     }
 
+    public Builder withLimit(int val) {
+      limit = val;
+      return this;
+    }
+
     public AddAndGetRequest build() {
       return new AddAndGetRequest(this);
     }
@@ -176,6 +189,7 @@ public class AddAndGetRequest {
     AddAndGetRequest that = (AddAndGetRequest) o;
 
     if (cost != that.cost) return false;
+    if (limit != that.limit) return false;
     if (resource != null ? !resource.equals(that.resource) : that.resource != null) return false;
     if (limitName != null ? !limitName.equals(that.limitName) : that.limitName != null)
       return false;
@@ -196,6 +210,7 @@ public class AddAndGetRequest {
     result = 31 * result + (expiration != null ? expiration.hashCode() : 0);
     result = 31 * result + (eventTimestamp != null ? eventTimestamp.hashCode() : 0);
     result = 31 * result + cost;
+    result = 31 * result + limit;
     result = 31 * result + (bucket != null ? bucket.hashCode() : 0);
     return result;
   }
@@ -220,6 +235,8 @@ public class AddAndGetRequest {
         + cost
         + ", bucket="
         + bucket
+        + ", limit="
+        + limit
         + '}';
   }
 }

--- a/src/main/java/com/coveo/spillway/storage/utils/Capacity.java
+++ b/src/main/java/com/coveo/spillway/storage/utils/Capacity.java
@@ -47,6 +47,11 @@ public class Capacity {
     this.total = new AtomicInteger(total);
   }
 
+  public Integer addAndGetWithLimit(int cost, int limit) {
+    return delta.accumulateAndGet(cost, (left, right) -> left > limit ? left : left + right)
+        + total.get();
+  }
+
   public Integer addAndGet(int cost) {
     return delta.addAndGet(cost) + total.get();
   }

--- a/src/test/java/com/coveo/spillway/SpillwayTryUpdateAndVerifyLimitTest.java
+++ b/src/test/java/com/coveo/spillway/SpillwayTryUpdateAndVerifyLimitTest.java
@@ -1,0 +1,506 @@
+package com.coveo.spillway;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyListOf;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.coveo.spillway.exception.SpillwayLimitExceededException;
+import com.coveo.spillway.exception.SpillwayLimitsWithSameNameException;
+import com.coveo.spillway.limit.Limit;
+import com.coveo.spillway.limit.LimitBuilder;
+import com.coveo.spillway.limit.LimitDefinition;
+import com.coveo.spillway.limit.LimitKey;
+import com.coveo.spillway.limit.override.LimitOverride;
+import com.coveo.spillway.limit.override.LimitOverrideBuilder;
+import com.coveo.spillway.storage.InMemoryStorage;
+import com.coveo.spillway.storage.LimitUsageStorage;
+import com.coveo.spillway.storage.utils.AddAndGetRequest;
+import com.coveo.spillway.trigger.LimitTriggerCallback;
+import com.coveo.spillway.trigger.ValueThresholdTrigger;
+import com.google.common.collect.ImmutableMap;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.IntStream;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+public class SpillwayTryUpdateAndVerifyLimitTest {
+
+  private static final int A_SMALLER_CAPACITY = 50;
+  private static final int A_CAPACITY = 100;
+  private static final int A_HIGHER_CAPACITY = 500;
+  private static final Duration A_DURATION = Duration.ofHours(1);
+  private static final Duration A_SHORT_DURATION = Duration.ofSeconds(2);
+  private static final String JOHN = "john";
+  private static final String A_LIMIT_NAME = "perUser";
+
+  private class User {
+
+    private String name;
+    private String ip;
+
+    User(String name, String ip) {
+      this.name = name;
+      this.ip = ip;
+    }
+
+    String getName() {
+      return name;
+    }
+
+    String getIp() {
+      return ip;
+    }
+  }
+
+  private User john = new User(JOHN, "127.0.0.1");
+  private User gina = new User("gina", "127.0.0.1");
+
+  private LimitUsageStorage mockedStorage;
+  private LimitUsageStorage inMemoryStorage;
+  private Clock clock;
+
+  private SpillwayFactory inMemoryFactory;
+  private SpillwayFactory mockedFactory;
+
+  @Before
+  public void setup() {
+    clock = mock(Clock.class);
+    inMemoryStorage = new InMemoryStorage();
+    inMemoryFactory = new SpillwayFactory(inMemoryStorage, clock);
+
+    mockedStorage = mock(LimitUsageStorage.class);
+    mockedFactory = new SpillwayFactory(mockedStorage);
+
+    when(clock.instant()).thenReturn(Instant.now());
+  }
+
+  @Test
+  public void simpleLimit() throws Exception {
+    Limit<User> limit1 =
+        LimitBuilder.of("perUser", User::getName).to(2).per(Duration.ofHours(1)).build();
+    Spillway<User> spillway = inMemoryFactory.enforce("testResource", limit1);
+
+    assertThat(spillway.tryUpdateAndVerifyLimit(john)).isTrue();
+    assertThat(spillway.tryUpdateAndVerifyLimit(john)).isTrue();
+    assertThat(spillway.tryUpdateAndVerifyLimit(john))
+        .isFalse(); // Third tryUpdateAndVerifyLimit fails
+  }
+
+  @Test(expected = SpillwayLimitsWithSameNameException.class)
+  public void multipleLimitsWithOverlap() throws Exception {
+    Limit<User> limit1 =
+        LimitBuilder.of("perUser", User::getName).to(5).per(Duration.ofHours(1)).build();
+    Limit<User> limit2 =
+        LimitBuilder.of("perUser", User::getName).to(1).per(Duration.ofSeconds(1)).build();
+    inMemoryFactory.enforce("testResource", limit1, limit2);
+  }
+
+  @Test
+  public void multipleLimitsNoOverlap() throws Exception {
+    Limit<User> ipLimit =
+        LimitBuilder.of("perIp", User::getIp).to(1).per(Duration.ofHours(1)).build();
+    Limit<User> userLimit =
+        LimitBuilder.of("perUser", User::getName).to(1).per(Duration.ofHours(1)).build();
+    Spillway<User> spillway = inMemoryFactory.enforce("testResource", ipLimit, userLimit);
+
+    assertThat(spillway.tryUpdateAndVerifyLimit(john)).isTrue();
+    assertThat(spillway.tryUpdateAndVerifyLimit(gina)).isFalse(); // Gina is on John's IP.
+  }
+
+  @Test
+  public void multipleResourcesEachHaveTheirOwnLimit() throws Exception {
+    Limit<User> userLimit =
+        LimitBuilder.of("perUser", User::getName).to(1).per(Duration.ofHours(1)).build();
+    Spillway<User> spillway1 = inMemoryFactory.enforce("testResource1", userLimit);
+    Spillway<User> spillway2 = inMemoryFactory.enforce("testResource2", userLimit);
+
+    assertThat(spillway1.tryUpdateAndVerifyLimit(john)).isTrue();
+    assertThat(spillway2.tryUpdateAndVerifyLimit(john)).isTrue();
+    assertThat(spillway1.tryUpdateAndVerifyLimit(john)).isFalse();
+    assertThat(spillway2.tryUpdateAndVerifyLimit(john)).isFalse();
+  }
+
+  @Test
+  public void canUseDefaultPropertyExtractor() throws Exception {
+    Limit<String> userLimit = LimitBuilder.of("perUser").to(1).per(Duration.ofHours(1)).build();
+    Spillway<String> spillway = inMemoryFactory.enforce("testResource", userLimit);
+
+    assertThat(spillway.tryUpdateAndVerifyLimit(john.getName())).isTrue();
+    assertThat(spillway.tryUpdateAndVerifyLimit(john.getName())).isFalse();
+  }
+
+  @Test
+  public void canBeNotifiedWhenLimitIsExceeded() throws Exception {
+    LimitTriggerCallback callback = mock(LimitTriggerCallback.class);
+    Limit<User> userLimit =
+        LimitBuilder.of("perUser", User::getName)
+            .to(1)
+            .per(Duration.ofHours(1))
+            .withExceededCallback(callback)
+            .build();
+    Spillway<User> spillway = inMemoryFactory.enforce("testResource", userLimit);
+
+    spillway.tryUpdateAndVerifyLimit(john);
+    spillway.tryUpdateAndVerifyLimit(john);
+
+    verify(callback).trigger(userLimit.getDefinition(), john);
+  }
+
+  @Test
+  public void callThrowsAnExceptionWhichContainsAllTheDetails() throws Exception {
+    Limit<User> userLimit =
+        LimitBuilder.of("perUser", User::getName).to(1).per(Duration.ofHours(1)).build();
+    Spillway<User> spillway = inMemoryFactory.enforce("testResource", userLimit);
+
+    spillway.updateAndVerifyLimit(john);
+    try {
+      spillway.updateAndVerifyLimit(john);
+      fail("Expected an exception!");
+    } catch (SpillwayLimitExceededException ex) {
+      assertThat(ex.getExceededLimits()).hasSize(1);
+      assertThat(ex.getExceededLimits().get(0)).isEqualTo(userLimit.getDefinition());
+      assertThat(ex.getContext()).isEqualTo(john);
+    }
+  }
+
+  @Test
+  public void callThrowsForMultipleBreachedLimits() throws Exception {
+    Limit<User> userLimit =
+        LimitBuilder.of("perUser", User::getName).to(1).per(Duration.ofHours(1)).build();
+    Limit<User> ipLimit =
+        LimitBuilder.of("perIp", User::getIp).to(1).per(Duration.ofHours(1)).build();
+
+    Spillway<User> spillway = inMemoryFactory.enforce("testResource", userLimit, ipLimit);
+
+    spillway.updateAndVerifyLimit(john);
+    try {
+      spillway.updateAndVerifyLimit(john);
+      fail("Expected an exception!");
+    } catch (SpillwayLimitExceededException ex) {
+      assertThat(ex.getExceededLimits()).hasSize(2);
+      assertThat(ex.getExceededLimits()).contains(userLimit.getDefinition());
+      assertThat(ex.getExceededLimits()).contains(ipLimit.getDefinition());
+      assertThat(ex.getContext()).isEqualTo(john);
+    }
+  }
+
+  @Test
+  public void bucketChangesWhenTimePasses() throws Exception {
+    Limit<User> userLimit =
+        LimitBuilder.of("perUser", User::getName).to(1).per(Duration.ofSeconds(1)).build();
+    Spillway<User> spillway = inMemoryFactory.enforce("testResource", userLimit);
+
+    assertThat(spillway.tryUpdateAndVerifyLimit(john)).isTrue();
+    assertThat(spillway.tryUpdateAndVerifyLimit(john)).isFalse();
+
+    // Fake sleep two seconds to ensure that we bump to another bucket
+    when(clock.instant()).thenReturn(Instant.now().plusSeconds(2));
+
+    assertThat(spillway.tryUpdateAndVerifyLimit(john)).isTrue();
+  }
+
+  @Test
+  public void capacityNotIncrementedIfLimitTriggered() throws Exception {
+    Limit<User> limit1 =
+        LimitBuilder.of("perUser", User::getName).to(0).per(Duration.ofHours(1)).build();
+    Spillway<User> spillway = inMemoryFactory.enforce("testResource", limit1);
+
+    assertThat(spillway.tryUpdateAndVerifyLimit(john)).isFalse();
+
+    Map<LimitKey, Integer> counters = inMemoryStorage.getCurrentLimitCounters();
+
+    assertThat(counters.values()).containsExactly(1);
+  }
+
+  @Test
+  public void canGetCurrentLimitStatus() throws Exception {
+    Limit<User> userLimit =
+        LimitBuilder.of("perUser", User::getName).to(2).per(Duration.ofHours(1)).build();
+    Spillway<User> spillway = inMemoryFactory.enforce("testResource", userLimit);
+
+    spillway.updateAndVerifyLimit(john);
+    spillway.updateAndVerifyLimit(gina);
+    spillway.updateAndVerifyLimit(john);
+
+    Map<LimitKey, Integer> limitStatuses = spillway.debugCurrentLimitCounters();
+    assertThat(limitStatuses).hasSize(2);
+    assertThat(limitStatuses.toString()).isNotEmpty();
+
+    Optional<LimitKey> johnKey =
+        limitStatuses
+            .keySet()
+            .stream()
+            .filter(key -> key.getProperty().equals(john.getName()))
+            .findFirst();
+    assertThat(johnKey.isPresent()).isTrue();
+    assertThat(limitStatuses.get(johnKey.get())).isEqualTo(2);
+
+    Optional<LimitKey> ginaKey =
+        limitStatuses
+            .keySet()
+            .stream()
+            .filter(key -> key.getProperty().equals(gina.getName()))
+            .findFirst();
+    assertThat(ginaKey.isPresent()).isTrue();
+    assertThat(limitStatuses.get(ginaKey.get())).isEqualTo(1);
+  }
+
+  @Test
+  public void ifCallbackThrowsWeIgnoreThatCallbackAndContinue() throws Exception {
+    LimitTriggerCallback callbackThatIsOkay = mock(LimitTriggerCallback.class);
+    LimitTriggerCallback callbackThatThrows = mock(LimitTriggerCallback.class);
+    doThrow(RuntimeException.class)
+        .when(callbackThatThrows)
+        .trigger(any(LimitDefinition.class), any(Object.class));
+    Limit<User> ipLimit1 =
+        LimitBuilder.of("perIp1", User::getIp)
+            .to(1)
+            .per(Duration.ofHours(1))
+            .withExceededCallback(callbackThatThrows)
+            .build();
+    Limit<User> userLimit =
+        LimitBuilder.of("perUser", User::getName)
+            .to(1)
+            .per(Duration.ofHours(1))
+            .withExceededCallback(callbackThatIsOkay)
+            .build();
+    Limit<User> ipLimit2 =
+        LimitBuilder.of("perIp2", User::getIp)
+            .to(1)
+            .per(Duration.ofHours(1))
+            .withExceededCallback(callbackThatThrows)
+            .build();
+    Spillway<User> spillway =
+        inMemoryFactory.enforce("testResource", ipLimit1, userLimit, ipLimit2);
+
+    spillway.tryUpdateAndVerifyLimit(john);
+    spillway.tryUpdateAndVerifyLimit(john);
+
+    verify(callbackThatThrows).trigger(ipLimit1.getDefinition(), john);
+    verify(callbackThatIsOkay).trigger(userLimit.getDefinition(), john);
+    verify(callbackThatThrows).trigger(ipLimit2.getDefinition(), john);
+  }
+
+  @Test
+  public void canExceedLimitByDoingALargeIncrement() throws Exception {
+    Limit<User> userLimit =
+        LimitBuilder.of("perUser", User::getName).to(2).per(Duration.ofHours(1)).build();
+    Spillway<User> spillway = inMemoryFactory.enforce("testResource", userLimit);
+
+    try {
+      spillway.updateAndVerifyLimit(john, 3);
+      fail("Expected an exception");
+    } catch (SpillwayLimitExceededException e) {
+      assertThat(e.getExceededLimits()).hasSize(1);
+      assertThat(e.getExceededLimits().get(0)).isEqualTo(userLimit.getDefinition());
+    }
+  }
+
+  @Test
+  public void costCanBeALargeNumber() throws Exception {
+    Limit<User> userLimit =
+        LimitBuilder.of("perUser", User::getName).to(4).per(Duration.ofHours(1)).build();
+    Spillway<User> spillway = inMemoryFactory.enforce("testResource", userLimit);
+
+    assertThat(spillway.tryUpdateAndVerifyLimit(john, 4)).isTrue();
+    assertThat(spillway.tryUpdateAndVerifyLimit(john, 1)).isFalse();
+  }
+
+  @Test
+  public void canAddLimitTriggers() throws Exception {
+    LimitTriggerCallback callback = mock(LimitTriggerCallback.class);
+    ValueThresholdTrigger trigger = new ValueThresholdTrigger(5, callback);
+
+    Limit<User> userLimit =
+        LimitBuilder.of("perUser", User::getName)
+            .to(15)
+            .per(Duration.ofHours(1))
+            .withLimitTrigger(trigger)
+            .build();
+    Spillway<User> spillway = inMemoryFactory.enforce("testResource", userLimit);
+
+    spillway.tryUpdateAndVerifyLimit(john, 5);
+    verify(callback, never()).trigger(userLimit.getDefinition(), john);
+    spillway.tryUpdateAndVerifyLimit(john, 1);
+    verify(callback, times(1)).trigger(userLimit.getDefinition(), john);
+    // Calling it again does not lead to another alarm.
+    spillway.tryUpdateAndVerifyLimit(john, 1);
+    verify(callback, times(1)).trigger(userLimit.getDefinition(), john);
+  }
+
+  @Test
+  public void triggersAreIgnoreIfTheStorageReturnsAnIncoherentResponse() throws Exception {
+    when(mockedStorage.addAndGetWithLimit(anyListOf(AddAndGetRequest.class)))
+        .thenReturn(
+            ImmutableMap.of(
+                mock(LimitKey.class), 1, mock(LimitKey.class), 2, mock(LimitKey.class), 3));
+
+    LimitTriggerCallback callback = mock(LimitTriggerCallback.class);
+    ValueThresholdTrigger trigger = new ValueThresholdTrigger(5, callback);
+    Limit<User> userLimit =
+        LimitBuilder.of("perUser", User::getName)
+            .to(15)
+            .per(Duration.ofHours(1))
+            .withLimitTrigger(trigger)
+            .build();
+
+    Spillway<User> spillway = mockedFactory.enforce("testResource", userLimit);
+    assertThat(spillway.tryUpdateAndVerifyLimit(john, 100)).isTrue();
+
+    verify(callback, never()).trigger(any(LimitDefinition.class), any());
+  }
+
+  @Test
+  public void canAddCapacityLimitOverride() throws Exception {
+    LimitOverride override = LimitOverrideBuilder.of(JOHN).to(A_CAPACITY).per(A_DURATION).build();
+
+    Limit<User> userLimit =
+        LimitBuilder.of("perUser", User::getName)
+            .to(A_HIGHER_CAPACITY)
+            .per(A_DURATION)
+            .withLimitOverride(override)
+            .build();
+
+    Spillway<User> spillway = inMemoryFactory.enforce("testResource", userLimit);
+    assertThat(spillway.tryUpdateAndVerifyLimit(john, A_CAPACITY + 10)).isFalse();
+  }
+
+  @Test
+  public void canAddExpirationLimitOverride() throws Exception {
+    LimitOverride override =
+        LimitOverrideBuilder.of(JOHN).to(A_CAPACITY).per(A_SHORT_DURATION).build();
+
+    Limit<User> userLimit =
+        LimitBuilder.of("perUser", User::getName)
+            .to(A_CAPACITY)
+            .per(A_DURATION)
+            .withLimitOverride(override)
+            .build();
+
+    Spillway<User> spillway = inMemoryFactory.enforce("testResource", userLimit);
+    assertThat(spillway.tryUpdateAndVerifyLimit(john, A_CAPACITY)).isTrue();
+    assertThat(spillway.tryUpdateAndVerifyLimit(john, 1)).isFalse();
+
+    // Fake sleep two seconds to ensure that we bump to another bucket
+    when(clock.instant()).thenReturn(Instant.now().plusSeconds(2));
+
+    assertThat(spillway.tryUpdateAndVerifyLimit(john, A_CAPACITY)).isTrue();
+  }
+
+  @Test
+  public void canAddTriggersLimitOverride() throws Exception {
+    ArgumentCaptor<LimitDefinition> definitionCaptor =
+        ArgumentCaptor.forClass(LimitDefinition.class);
+
+    LimitTriggerCallback limitCallback = mock(LimitTriggerCallback.class);
+    LimitTriggerCallback overrideCallback = mock(LimitTriggerCallback.class);
+
+    LimitOverride override =
+        LimitOverrideBuilder.of(JOHN)
+            .to(A_HIGHER_CAPACITY)
+            .per(A_SHORT_DURATION)
+            .withExceededCallback(overrideCallback)
+            .build();
+
+    Limit<User> userLimit =
+        LimitBuilder.of(A_LIMIT_NAME, User::getName)
+            .to(A_CAPACITY)
+            .per(A_DURATION)
+            .withExceededCallback(limitCallback)
+            .withLimitOverride(override)
+            .build();
+
+    Spillway<User> spillway = inMemoryFactory.enforce("testResource", userLimit);
+    assertThat(spillway.tryUpdateAndVerifyLimit(john, A_HIGHER_CAPACITY + 10)).isFalse();
+
+    verify(limitCallback, never()).trigger(any(), any());
+    verify(overrideCallback).trigger(definitionCaptor.capture(), eq(john));
+
+    assertThat(definitionCaptor.getValue().getCapacity()).isEqualTo(A_HIGHER_CAPACITY);
+    assertThat(definitionCaptor.getValue().getExpiration()).isEqualTo(A_SHORT_DURATION);
+    assertThat(definitionCaptor.getValue().getName()).isEqualTo(A_LIMIT_NAME);
+  }
+
+  @Test
+  public void testAddMultipleLimitOverridesForSameProperty() throws Exception {
+    LimitOverride override = LimitOverrideBuilder.of(JOHN).to(A_CAPACITY).per(A_DURATION).build();
+    LimitOverride anotherOverride =
+        LimitOverrideBuilder.of(JOHN).to(A_SMALLER_CAPACITY).per(A_DURATION).build();
+
+    Limit<User> userLimit =
+        LimitBuilder.of("perUser", User::getName)
+            .to(A_HIGHER_CAPACITY)
+            .per(A_DURATION)
+            .withLimitOverride(override)
+            .withLimitOverride(anotherOverride)
+            .build();
+
+    Spillway<User> spillway = inMemoryFactory.enforce("testResource", userLimit);
+    assertThat(spillway.tryUpdateAndVerifyLimit(john, A_SMALLER_CAPACITY + 10)).isFalse();
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void positiveCostOnlyCall() throws Exception {
+    Limit<User> limit1 =
+        LimitBuilder.of("perUser", User::getName).to(2).per(Duration.ofHours(1)).build();
+    Spillway<User> spillway = inMemoryFactory.enforce("testResource", limit1);
+
+    spillway.call(john, 0);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void positiveCostOnlyTryCall() throws Exception {
+    Limit<User> limit1 =
+        LimitBuilder.of("perUser", User::getName).to(2).per(Duration.ofHours(1)).build();
+    Spillway<User> spillway = inMemoryFactory.enforce("testResource", limit1);
+
+    spillway.tryUpdateAndVerifyLimit(john, 0);
+  }
+
+  @Test
+  public void checkLimit() throws Exception {
+    Limit<User> limit1 =
+        LimitBuilder.of("perUser", User::getName).to(3).per(Duration.ofHours(1)).build();
+    Spillway<User> spillway = inMemoryFactory.enforce("testResource", limit1);
+
+    assertThat(spillway.checkLimit(john)).isTrue();
+    spillway.updateAndVerifyLimit(john, 2);
+    assertThat(spillway.checkLimit(john)).isTrue();
+    assertThat(spillway.checkLimit(john, 2)).isFalse();
+    spillway.updateAndVerifyLimit(john);
+    assertThat(spillway.checkLimit(john)).isFalse();
+  }
+
+  @Test
+  public void tryUpdateAndVerifyLimitMultiThread() throws Exception {
+    IntStream.range(0, 10)
+        .forEach(
+            i -> {
+              InMemoryStorage inMemoryStorage = new InMemoryStorage();
+              SpillwayFactory inMemoryFactory = new SpillwayFactory(inMemoryStorage);
+              Limit<User> userLimit =
+                  LimitBuilder.of("perUser", User::getName).to(100).per(A_DURATION).build();
+              Spillway<User> spillway = inMemoryFactory.enforce("testResource", userLimit);
+              Optional<Boolean> limitReached =
+                  IntStream.range(0, 101)
+                      .parallel()
+                      .mapToObj(j -> spillway.tryUpdateAndVerifyLimit(john))
+                      .reduce(Boolean::logicalAnd);
+              Assert.assertFalse(limitReached.orElse(true));
+            });
+  }
+}


### PR DESCRIPTION
This PR contains not a fix but more of a new API that provides same functionality of `tryCall` with thread safety. 

The existing `tryCall` seems to be not thread safe and can run into race conditions and the limit counter may end up giving unpredictable results. This can be tested with the test method in `TryUpdateAndVerifyLimitTest:: tryUpdateAndVerifyLimitMultiThread`. The existing issue of the API is that we read the counter value from underling `storage` and verify if the counter has exceeded the limit and then update the counter later. This is not thread safe as many threads will do the same comparison locally in different times after reading the value.

The solution is to do a `setAndGet` one time operation of the counter(s) at the storage level. This provides the thread safety as now the `storage` is responsible of the atomicity of the operation. In Redis storage, this is done using https://redis.io/commands/eval that provides atomicity of multi-operations in elements. 

One main difference compared to `tryCall` in this API is that the final counter value will rather be `limit + cost` than `limit` (in general use,  limit + 1)

Pros of the new API:

- Thread safety in counters. From tests, it guarantees to enforce precise limits.

- Performance.  Though we use Lua scripts, the performance seems to improve as the whole API will make one trip to the underlying storage to increment and check the counter value. The performance results are:
```
INFO: tryUpdateAndVerifyLimit 1000000 times took 75665.8 ms (average of 0.0756658 ms per call)
INFO: tryCall 1000000 times took 114792.2 ms (average of 0.1147922 ms per call)
```
I have pretty much replicated the existing `SpillwayTest` to `SpillwayTryUpdateAndVerifyLimitTest` + a multi thread test.