### PR TITLE
Bumping jedis to latest major.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.coveo</groupId>
     <artifactId>spillway</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>${project.artifactId}</name>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.coveo</groupId>
     <artifactId>spillway</artifactId>
-    <version>2.1.2-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>${project.artifactId}</name>
@@ -77,7 +77,7 @@
         <dependency>
             <groupId>redis.clients</groupId>
             <artifactId>jedis</artifactId>
-            <version>2.8.1</version>
+            <version>4.2.1</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/com/coveo/spillway/storage/RedisStorage.java
+++ b/src/main/java/com/coveo/spillway/storage/RedisStorage.java
@@ -114,7 +114,7 @@ public class RedisStorage implements LimitUsageStorage {
 
         pipeline.sync();
       } catch (Throwable e) {
-        logger.error("Unable to close redis storage pipeline.", e);
+        logger.error("An exception occured while publishing limits to Redis.", e);
       }
     }
 
@@ -159,7 +159,7 @@ public class RedisStorage implements LimitUsageStorage {
 
         pipeline.sync();
       } catch (Throwable e) {
-        logger.error("Unable to close redis storage pipeline.", e);
+        logger.error("An exception occured while publishing limits to Redis.", e);
       }
     }
 


### PR DESCRIPTION
Context:

Jedis 4.x.x drops supports for multi and exec methods in pipeline. This pull-request aims at bumping spillway to the latest jedis version. Also, I modified the try catch statement to catch throwables, because some exceptions throwed by redis were not properly caught by this.


- Removing deprecated method on pipelines.
- Catching throwable instead of exception to make sure we handle any problem properly.